### PR TITLE
feat: get Stripe keys from environment file

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,16 +83,20 @@ export default defineNuxtConfig({
   modules: [
     'nuxt3-stripe'
   ],
-  stripe: {
-    apiKey: 'sk_test_123',
-    publishableKey: 'pk_test_123',
-  }
 })
 ```
 
 ## Configuration
 
-You can configure the module by providing the necessary Stripe keys and an optional API version in your `nuxt.config.js` file:
+Stripe keys can be added to the `.env` file...
+
+```env
+STRIPE_PUBLISHABLE_KEY="pk_live_..."
+STRIPE_API_KEY="sk_live_..."
+```
+
+...or to the Nuxt configuration file:
+
 
 ```ts
 export default defineNuxtConfig({
@@ -108,6 +112,8 @@ export default defineNuxtConfig({
   }
 })
 ```
+
+> We highly recommend you put your **production** keys in your `.env` file to avoid committing them
 
 ## Development
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -37,8 +37,8 @@ export default defineNuxtModule<ModuleOptions>({
     }
   },
   defaults: {
-      publishableKey: null,
-      apiKey: null,
+      publishableKey: process.env.STRIPE_PUBLISHABLE_KEY as string,
+      apiKey: process.env.STRIPE_API_KEY as string,
       apiVersion: '2022-11-15'
   },
   setup (options, nuxt) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description

By default, get Stripe keys from `.env` file. This allows us to set Stripe production keys in environment variables when running the application, while the `nuxt.config.ts` file will only contain test keys (`sk_test` and `pk_test`).

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)